### PR TITLE
Move sidebar logo to top

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -138,7 +138,7 @@ const App = () => {
     return (
         <div className="flex flex-col lg:flex-row min-h-screen bg-slate-100 font-sans">
             {/* Sidebar */}
-            <aside className="bg-gradient-to-b from-slate-800 to-slate-900 text-white w-full lg:w-80 p-8 flex flex-col items-center justify-center shadow-xl rounded-r-3xl">
+            <aside className="bg-gradient-to-b from-slate-800 to-slate-900 text-white w-full lg:w-80 p-8 pt-12 flex flex-col items-center justify-start shadow-xl rounded-r-3xl">
                 <div className="flex flex-col items-center">
                     <div className="mb-4">
                         {/* Real logo SVG */}


### PR DESCRIPTION
## Summary
- move the sidebar logo to the top and add top padding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854b73c2000832abb22c6e92ceaafef